### PR TITLE
Remove obsolete setuptools alias for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test=pytest
-
 [coverage:run]
 source = gcn
 omit = gcn/tests/*
@@ -40,8 +37,6 @@ packages = find:
 python_version = >=3.7
 install_requires =
     lxml
-tests_require =
-    pytest
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
pytest is no longer run using setup.py.