### PR TITLE
Remove deprecated license classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Science/Research
-    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: POSIX
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
See https://peps.python.org/pep-0639/#deprecate-license-classifiers.